### PR TITLE
Add Go REST API template with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.20-alpine AS builder
+WORKDIR /app
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o server ./cmd/app
+
+FROM alpine:3.18
+WORKDIR /root/
+COPY --from=builder /app/server .
+EXPOSE 8080
+CMD ["./server"]
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# go-rest-api-template
+# Go REST API Template
+
+This project provides a simple REST API for managing users using Go and PostgreSQL. It follows a minimal layered architecture and can be run in Docker.
+
+## Running with Docker Compose
+
+```bash
+docker-compose up --build
+```
+
+The application will be available on `http://localhost:8080` and connects to a PostgreSQL database exposed on port `5432`.
+
+## Endpoints
+
+- `POST /users` – create a user
+- `GET /users` – list users
+- `GET /users/show?id=1` – get user by ID
+

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"go-rest-api-template/internal/config"
+	"go-rest-api-template/internal/db"
+	"go-rest-api-template/internal/handler"
+	"go-rest-api-template/internal/repository"
+	"go-rest-api-template/internal/server"
+)
+
+func main() {
+	cfg := config.Load()
+
+	connStr := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable",
+		cfg.DBHost, cfg.DBPort, cfg.DBUser, cfg.DBPassword, cfg.DBName)
+	database, err := db.Connect(connStr)
+	if err != nil {
+		log.Fatalf("db connect: %v", err)
+	}
+
+	repo := repository.NewUserRepository(database)
+	userHandler := handler.NewUserHandler(repo)
+	srv := server.New(userHandler, cfg.ServerPort)
+
+	log.Printf("starting server on %s", cfg.ServerPort)
+	if err := srv.Start(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: app
+    ports:
+      - "5432:5432"
+  app:
+    build: .
+    environment:
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_USER: postgres
+      DB_PASSWORD: postgres
+      DB_NAME: app
+      SERVER_PORT: 8080
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db
+

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module go-rest-api-template
+
+go 1.24.3

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"os"
+)
+
+type Config struct {
+	DBHost     string
+	DBPort     string
+	DBUser     string
+	DBPassword string
+	DBName     string
+	ServerPort string
+}
+
+func Load() *Config {
+	cfg := &Config{}
+	cfg.DBHost = getEnv("DB_HOST", "postgres")
+	cfg.DBPort = getEnv("DB_PORT", "5432")
+	cfg.DBUser = getEnv("DB_USER", "postgres")
+	cfg.DBPassword = getEnv("DB_PASSWORD", "postgres")
+	cfg.DBName = getEnv("DB_NAME", "app")
+	cfg.ServerPort = getEnv("SERVER_PORT", "8080")
+	return cfg
+}
+
+func getEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -1,0 +1,10 @@
+package db
+
+import (
+	"database/sql"
+	_ "github.com/lib/pq"
+)
+
+func Connect(connStr string) (*sql.DB, error) {
+	return sql.Open("postgres", connStr)
+}

--- a/internal/handler/user_handler.go
+++ b/internal/handler/user_handler.go
@@ -1,0 +1,55 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"go-rest-api-template/internal/models"
+	"go-rest-api-template/internal/repository"
+)
+
+type UserHandler struct {
+	repo *repository.UserRepository
+}
+
+func NewUserHandler(repo *repository.UserRepository) *UserHandler {
+	return &UserHandler{repo: repo}
+}
+
+func (h *UserHandler) Create(w http.ResponseWriter, r *http.Request) {
+	var u models.User
+	if err := json.NewDecoder(r.Body).Decode(&u); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := h.repo.Create(&u); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (h *UserHandler) GetByID(w http.ResponseWriter, r *http.Request) {
+	idStr := r.URL.Query().Get("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		http.Error(w, "invalid id", http.StatusBadRequest)
+		return
+	}
+	user, err := h.repo.GetByID(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(user)
+}
+
+func (h *UserHandler) List(w http.ResponseWriter, r *http.Request) {
+	users, err := h.repo.List()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(users)
+}

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -1,0 +1,7 @@
+package models
+
+type User struct {
+	ID    int    `json:"id"`
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}

--- a/internal/repository/user_repository.go
+++ b/internal/repository/user_repository.go
@@ -1,0 +1,47 @@
+package repository
+
+import (
+	"database/sql"
+
+	"go-rest-api-template/internal/models"
+)
+
+type UserRepository struct {
+	db *sql.DB
+}
+
+func NewUserRepository(db *sql.DB) *UserRepository {
+	return &UserRepository{db: db}
+}
+
+func (r *UserRepository) Create(user *models.User) error {
+	_, err := r.db.Exec(`INSERT INTO users (name, email) VALUES ($1, $2)`, user.Name, user.Email)
+	return err
+}
+
+func (r *UserRepository) GetByID(id int) (*models.User, error) {
+	row := r.db.QueryRow(`SELECT id, name, email FROM users WHERE id=$1`, id)
+	u := &models.User{}
+	if err := row.Scan(&u.ID, &u.Name, &u.Email); err != nil {
+		return nil, err
+	}
+	return u, nil
+}
+
+func (r *UserRepository) List() ([]*models.User, error) {
+	rows, err := r.db.Query(`SELECT id, name, email FROM users`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	users := []*models.User{}
+	for rows.Next() {
+		u := &models.User{}
+		if err := rows.Scan(&u.ID, &u.Name, &u.Email); err != nil {
+			return nil, err
+		}
+		users = append(users, u)
+	}
+	return users, rows.Err()
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,45 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+
+	"go-rest-api-template/internal/handler"
+)
+
+type Server struct {
+	userHandler *handler.UserHandler
+	port        string
+}
+
+func New(userHandler *handler.UserHandler, port string) *Server {
+	return &Server{userHandler: userHandler, port: port}
+}
+
+func (s *Server) routes() {
+	http.HandleFunc("/users", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			s.userHandler.Create(w, r)
+			return
+		}
+		if r.Method == http.MethodGet {
+			s.userHandler.List(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	})
+
+	http.HandleFunc("/users/show", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			s.userHandler.GetByID(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	})
+}
+
+func (s *Server) Start() error {
+	s.routes()
+	addr := fmt.Sprintf(":%s", s.port)
+	return http.ListenAndServe(addr, nil)
+}


### PR DESCRIPTION
## Summary
- create layered Go REST API for users
- connect to Postgres and provide simple CRUD
- add Dockerfile and docker-compose.yml
- document usage

## Testing
- `go mod tidy` *(fails: module download blocked)*
- `go build ./cmd/app` *(fails: missing module)*

------
https://chatgpt.com/codex/tasks/task_e_68793115bb84832189d1d06e78ca1ed4