### PR TITLE
Update Dockerfile Go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine AS builder
+FROM golang:1.24-alpine AS builder
 WORKDIR /app
 COPY go.mod .
 COPY go.sum .


### PR DESCRIPTION
## Summary
- bump Go base image to 1.24-alpine

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879342b6e608321af8608be7cd8c5bc