### PR TITLE
Add database initialization for users table

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ docker-compose up --build
 ```
 
 The application will be available on `http://localhost:8080` and connects to a PostgreSQL database exposed on port `5432`.
+When the database container starts for the first time it executes `db/init.sql` to
+create the `users` table automatically.
 
 ## Endpoints
 

--- a/db/init.sql
+++ b/db/init.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    email TEXT NOT NULL UNIQUE
+);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       POSTGRES_DB: app
     ports:
       - "5432:5432"
+    volumes:
+      - ./db/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
   app:
     build: .
     environment:


### PR DESCRIPTION
## Summary
- add SQL script to create `users` table
- mount script into postgres container via docker-compose
- document automatic table creation

## Testing
- `go test ./...` *(fails: no module provides github.com/lib/pq)*

------
https://chatgpt.com/codex/tasks/task_e_687935a88538832193f971d13b91bd02