### PR TITLE
Add auth handler tests

### DIFF
--- a/internal/handler/auth_handler_test.go
+++ b/internal/handler/auth_handler_test.go
@@ -1,0 +1,60 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go-rest-api-template/internal/auth"
+	"go-rest-api-template/internal/models"
+)
+
+type stubAuthRepo struct {
+	user *models.User
+	err  error
+}
+
+func (s *stubAuthRepo) GetByUsername(username string) (*models.User, error) {
+	return s.user, s.err
+}
+
+func TestAuthHandler_Login_Success(t *testing.T) {
+	hash, _ := auth.HashPassword("pass")
+	repo := &stubAuthRepo{user: &models.User{ID: 1, Username: "u", PasswordHash: hash}}
+	h := NewAuthHandler(repo, "secret")
+
+	body := bytes.NewBufferString(`{"username":"u","password":"pass"}`)
+	req := httptest.NewRequest(http.MethodPost, "/login", body)
+	rr := httptest.NewRecorder()
+
+	h.Login(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if _, err := auth.ParseToken(resp["token"], "secret"); err != nil {
+		t.Fatalf("invalid token: %v", err)
+	}
+}
+
+func TestAuthHandler_Login_Invalid(t *testing.T) {
+	hash, _ := auth.HashPassword("pass")
+	repo := &stubAuthRepo{user: &models.User{ID: 1, Username: "u", PasswordHash: hash}}
+	h := NewAuthHandler(repo, "secret")
+
+	body := bytes.NewBufferString(`{"username":"u","password":"wrong"}`)
+	req := httptest.NewRequest(http.MethodPost, "/login", body)
+	rr := httptest.NewRecorder()
+
+	h.Login(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", rr.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- add tests for the login handler to verify successful and failed authentication

## Testing
- `go test ./...` *(fails: cannot download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687947b7d5d88321821276fc95232d2f